### PR TITLE
allow setting hashing algorithm

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ function fromFile(file, expected, done) {
 }
 
 function fromBuffer (buffer, expected, done) {
-  var actual = crypto.createHash('md5').update(buffer).digest('hex');
+  var hash = expected.hash || 'md5';
+  expected = expected.expected || expected;
+  var actual = crypto.createHash(hash).update(buffer).digest('hex');
   if (actual !== expected) {
     done(null, false, actual);
     return;

--- a/readme.markdown
+++ b/readme.markdown
@@ -14,7 +14,7 @@ npm i -S check-hash
 var checkHash = require('check-hash');
 var expectation = 'f8767c0bacc0ed516bfa22802dda573082b5bf463e5ea79a74087272ccb2d1e2'; // node v4.3.2
 
-checkHash.fromFile('./node.exe', expectation, function (err, passed, actual) {
+checkHash.fromFile('./node.exe', { hash: 'sha256', expectation: expectation }, function (err, passed, actual) {
   if (err) {
     done(err);
   } else if (!passed) {
@@ -27,6 +27,10 @@ checkHash.fromFile('./node.exe', expectation, function (err, passed, actual) {
 
 # `fromFile(file, expectedHash, done)`
 
+expectedHash can be either a string with hash or an object with two properties:
+- `hash` hashing algorithm to use ('md5', 'sha256')
+- `expected` string with expected hash
+
 Computes a hash of the contents for the provided `file`, after reading it, and then calls `done(err, passed, actual)`.
 
 - `err` reports any errors that occurred while reading the file or computing the hash.
@@ -35,6 +39,10 @@ Computes a hash of the contents for the provided `file`, after reading it, and t
 
 # `fromBuffer(buffer, expectedHash, done)`
 
+expectedHash can be either a string with hash or an object with two properties:
+- `hash` hashing algorithm to use ('md5', 'sha256')
+- `expected` string with expected hash
+ 
 Computes a hash of the provided `buffer`, and then calls `done(err, passed, actual)`.
 
 - `err` reports any errors that occurred while computing the hash.


### PR DESCRIPTION
hashing algorithm can now be set:

`check-hash.fromFile('node.exe', { hash: 'sha256', expected:'myexpectedhash' }, function () { console.log('done'); });`

kept backward compatible
